### PR TITLE
Support multiple platforms.

### DIFF
--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -99,7 +99,7 @@ def check_dist_restriction(options, check_target=False):
     """
     dist_restriction_set = any([
         options.python_version,
-        options.platform,
+        options.platforms,
         options.abi,
         options.implementation,
     ])
@@ -491,11 +491,13 @@ def only_binary():
 platform = partial(
     Option,
     '--platform',
-    dest='platform',
+    dest='platforms',
     metavar='platform',
+    action='append',
     default=None,
     help=("Only use wheels compatible with <platform>. "
-          "Defaults to the platform of the running system."),
+          "Defaults to the platform of the running system. "
+          "This option can be used multiple times."),
 )  # type: Callable[..., Option]
 
 
@@ -605,7 +607,7 @@ def add_target_python_options(cmd_opts):
 def make_target_python(options):
     # type: (Values) -> TargetPython
     target_python = TargetPython(
-        platform=options.platform,
+        platforms=options.platforms,
         py_version_info=options.python_version,
         abi=options.abi,
         implementation=options.implementation,

--- a/src/pip/_internal/models/target_python.py
+++ b/src/pip/_internal/models/target_python.py
@@ -1,6 +1,6 @@
 import sys
 
-from pip._internal.pep425tags import get_supported, version_info_to_nodot
+from pip._internal.pep425tags import get_supported
 from pip._internal.utils.misc import normalize_version_info
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
@@ -18,18 +18,18 @@ class TargetPython(object):
 
     def __init__(
         self,
-        platform=None,  # type: Optional[str]
+        platforms=None,  # type: Optional[List[str]]
         py_version_info=None,  # type: Optional[Tuple[int, ...]]
         abi=None,  # type: Optional[str]
         implementation=None,  # type: Optional[str]
     ):
         # type: (...) -> None
         """
-        :param platform: A string or None. If None, searches for packages
-            that are supported by the current system. Otherwise, will find
-            packages that can be built on the platform passed in. These
-            packages will only be downloaded for distribution: they will
-            not be built locally.
+        :param platforms: A list of platform strings or None. If None,
+            searches for packages that are supported by the current system.
+            Otherwise, will find packages that can be built on the platforms
+            passed in. These packages will only be downloaded for
+            distribution: they will not be built locally.
         :param py_version_info: An optional tuple of ints representing the
             Python version information to use (e.g. `sys.version_info[:3]`).
             This can have length 1, 2, or 3 when provided.
@@ -50,7 +50,7 @@ class TargetPython(object):
 
         self.abi = abi
         self.implementation = implementation
-        self.platform = platform
+        self.platforms = platforms
         self.py_version = py_version
         self.py_version_info = py_version_info
 
@@ -69,7 +69,7 @@ class TargetPython(object):
             )
 
         key_values = [
-            ('platform', self.platform),
+            ('platforms', self.platforms),
             ('version_info', display_version),
             ('abi', self.abi),
             ('implementation', self.implementation),
@@ -87,17 +87,9 @@ class TargetPython(object):
         The tags are returned in order of preference (most preferred first).
         """
         if self._valid_tags is None:
-            # Pass versions=None if no py_version_info was given since
-            # versions=None uses special default logic.
-            py_version_info = self._given_py_version_info
-            if py_version_info is None:
-                version = None
-            else:
-                version = version_info_to_nodot(py_version_info)
-
             tags = get_supported(
-                version=version,
-                platform=self.platform,
+                version_info=self._given_py_version_info,
+                platforms=self.platforms,
                 abi=self.abi,
                 impl=self.implementation,
             )

--- a/tests/unit/test_models_wheel.py
+++ b/tests/unit/test_models_wheel.py
@@ -75,7 +75,7 @@ class TestWheelFile(object):
         Wheels built for macOS 10.6 are supported on 10.9
         """
         tags = pep425tags.get_supported(
-            '27', platform='macosx_10_9_intel', impl='cp'
+            (2, 7), platforms=['macosx_10_9_intel'], impl='cp'
         )
         w = Wheel('simple-0.1-cp27-none-macosx_10_6_intel.whl')
         assert w.supported(tags=tags)
@@ -87,7 +87,7 @@ class TestWheelFile(object):
         Wheels built for macOS 10.9 are not supported on 10.6
         """
         tags = pep425tags.get_supported(
-            '27', platform='macosx_10_6_intel', impl='cp'
+            (2, 7), platforms=['macosx_10_6_intel'], impl='cp'
         )
         w = Wheel('simple-0.1-cp27-none-macosx_10_9_intel.whl')
         assert not w.supported(tags=tags)
@@ -97,22 +97,22 @@ class TestWheelFile(object):
         Multi-arch wheels (intel) are supported on components (i386, x86_64)
         """
         universal = pep425tags.get_supported(
-            '27', platform='macosx_10_5_universal', impl='cp'
+            (2, 7), platforms=['macosx_10_5_universal'], impl='cp'
         )
         intel = pep425tags.get_supported(
-            '27', platform='macosx_10_5_intel', impl='cp'
+            (2, 7), platforms=['macosx_10_5_intel'], impl='cp'
         )
         x64 = pep425tags.get_supported(
-            '27', platform='macosx_10_5_x86_64', impl='cp'
+            (2, 7), platforms=['macosx_10_5_x86_64'], impl='cp'
         )
         i386 = pep425tags.get_supported(
-            '27', platform='macosx_10_5_i386', impl='cp'
+            (2, 7), platforms=['macosx_10_5_i386'], impl='cp'
         )
         ppc = pep425tags.get_supported(
-            '27', platform='macosx_10_5_ppc', impl='cp'
+            (2, 7), platforms=['macosx_10_5_ppc'], impl='cp'
         )
         ppc64 = pep425tags.get_supported(
-            '27', platform='macosx_10_5_ppc64', impl='cp'
+            (2, 7), platforms=['macosx_10_5_ppc64'], impl='cp'
         )
 
         w = Wheel('simple-0.1-cp27-none-macosx_10_5_intel.whl')
@@ -135,10 +135,10 @@ class TestWheelFile(object):
         Single-arch wheels (x86_64) are not supported on multi-arch (intel)
         """
         universal = pep425tags.get_supported(
-            '27', platform='macosx_10_5_universal', impl='cp'
+            (2, 7), platforms=['macosx_10_5_universal'], impl='cp'
         )
         intel = pep425tags.get_supported(
-            '27', platform='macosx_10_5_intel', impl='cp'
+            (2, 7), platforms=['macosx_10_5_intel'], impl='cp'
         )
 
         w = Wheel('simple-0.1-cp27-none-macosx_10_5_i386.whl')

--- a/tests/unit/test_pep425tags.py
+++ b/tests/unit/test_pep425tags.py
@@ -15,21 +15,6 @@ def test_format_tag(file_tag, expected):
     assert actual == expected
 
 
-@pytest.mark.parametrize('version_info, expected', [
-    ((2,), '2'),
-    ((2, 8), '28'),
-    ((3,), '3'),
-    ((3, 6), '36'),
-    # Test a tuple of length 3.
-    ((3, 6, 5), '36'),
-    # Test a 2-digit minor version.
-    ((3, 10), '310'),
-])
-def test_version_info_to_nodot(version_info, expected):
-    actual = pep425tags.version_info_to_nodot(version_info)
-    assert actual == expected
-
-
 class TestPEP425Tags(object):
 
     def mock_get_config_var(self, **kwd):
@@ -244,7 +229,7 @@ class TestManylinux2010Tags(object):
         Specifying manylinux2010 implies manylinux1.
         """
         groups = {}
-        supported = pep425tags.get_supported(platform=manylinux2010)
+        supported = pep425tags.get_supported(platforms=[manylinux2010])
         for pyimpl, abi, arch in supported:
             groups.setdefault((pyimpl, abi), []).append(arch)
 
@@ -294,7 +279,7 @@ class TestManylinux2014Tags(object):
         Specifying manylinux2014 implies manylinux2010/manylinux1.
         """
         groups = {}
-        supported = pep425tags.get_supported(platform=manylinuxA)
+        supported = pep425tags.get_supported(platforms=[manylinuxA])
         for pyimpl, abi, arch in supported:
             groups.setdefault((pyimpl, abi), []).append(arch)
 

--- a/tests/unit/test_target_python.py
+++ b/tests/unit/test_target_python.py
@@ -45,16 +45,16 @@ class TestTargetPython:
         ({}, ''),
         (dict(py_version_info=(3, 6)), "version_info='3.6'"),
         (
-            dict(platform='darwin', py_version_info=(3, 6)),
-            "platform='darwin' version_info='3.6'",
+            dict(platforms=['darwin'], py_version_info=(3, 6)),
+            "platforms=['darwin'] version_info='3.6'",
         ),
         (
             dict(
-                platform='darwin', py_version_info=(3, 6), abi='cp36m',
+                platforms=['darwin'], py_version_info=(3, 6), abi='cp36m',
                 implementation='cp'
             ),
             (
-                "platform='darwin' version_info='3.6' abi='cp36m' "
+                "platforms=['darwin'] version_info='3.6' abi='cp36m' "
                 "implementation='cp'"
             ),
         ),
@@ -64,29 +64,27 @@ class TestTargetPython:
         actual = target_python.format_given()
         assert actual == expected
 
-    @pytest.mark.parametrize('py_version_info, expected_version', [
-        ((), ''),
-        ((2, ), '2'),
-        ((3, ), '3'),
-        ((3, 7), '37'),
-        ((3, 7, 3), '37'),
+    @pytest.mark.parametrize('py_version_info', [
+        ((), ),
+        ((2, ), ),
+        ((3, ), ),
+        ((3, 7), ),
+        ((3, 7, 3), ),
         # Check a minor version with two digits.
-        ((3, 10, 1), '310'),
+        ((3, 10, 1), ),
         # Check that versions=None is passed to get_tags().
-        (None, None),
+        (None, ),
     ])
     @patch('pip._internal.models.target_python.get_supported')
-    def test_get_tags(
-        self, mock_get_supported, py_version_info, expected_version,
-    ):
+    def test_get_tags(self, mock_get_supported, py_version_info):
         mock_get_supported.return_value = ['tag-1', 'tag-2']
 
         target_python = TargetPython(py_version_info=py_version_info)
         actual = target_python.get_tags()
         assert actual == ['tag-1', 'tag-2']
 
-        actual = mock_get_supported.call_args[1]['version']
-        assert actual == expected_version
+        actual = mock_get_supported.call_args[1]['version_info']
+        assert actual == py_version_info
 
         # Check that the value was cached.
         assert target_python._valid_tags == ['tag-1', 'tag-2']


### PR DESCRIPTION
Allow multiple --platform arguments to support downloading wheels for
manylinux* and linux when it's known out of band that this is safe.