### PR TITLE
Allow non top-level .dist-info dirs in wheels.

### DIFF
--- a/src/pip/_internal/operations/install/wheel.py
+++ b/src/pip/_internal/operations/install/wheel.py
@@ -383,6 +383,7 @@ def install_unpacked_wheel(
                     continue
                 elif (
                     is_base and
+                    basedir == '' and
                     s.endswith('.dist-info')
                 ):
                     assert not info_dir, (

--- a/tests/functional/test_install_wheel.py
+++ b/tests/functional/test_install_wheel.py
@@ -472,3 +472,22 @@ def test_wheel_install_fails_with_unrelated_dist_info(script):
         "'simple-0.1.0.dist-info' does not start with 'unrelated'"
         in result.stderr
     )
+
+
+def test_wheel_install_succeeds_with_nested_dist_info(script):
+    package = create_basic_wheel_for_package(
+        script,
+        "simple",
+        "0.1.0",
+        extra_files={
+            "simple/_vendor/unrelated-2.0.0.dist-info/WHEEL": (
+                "Wheel-Version: 1.0"
+            ),
+            "simple/_vendor/unrelated-2.0.0.dist-info/METADATA": (
+                "Name: unrelated\nVersion: 2.0.0\n"
+            ),
+        },
+    )
+    script.pip(
+        "install", "--no-cache-dir", "--no-index", package, expect_error=False
+    )

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -997,7 +997,7 @@ def create_basic_wheel_for_package(
 
     for fname in files:
         path = script.temp_path / fname
-        path.parent.mkdir(exist_ok=True)
+        path.parent.mkdir(exist_ok=True, parents=True)
         path.write_text(files[fname])
 
     retval = script.scratch_path / archive_name


### PR DESCRIPTION
It seems #7494 disallows non top-level .dist-info dirs. This appears to
not have been intentional. Restore support for wheels with nested
(vendored) distributions since they do not pose ambiguity probmens for
pip.
