### PR TITLE
Pin virtualenv dep.

### DIFF
--- a/tools/requirements/tests.txt
+++ b/tools/requirements/tests.txt
@@ -12,6 +12,6 @@ pytest-xdist<1.28.0
 pyyaml
 setuptools>=39.2.0  # Needed for `setuptools.wheel.Wheel` support.
 scripttest
-https://github.com/pypa/virtualenv/archive/master.zip#egg=virtualenv
+virtualenv==16.7.9
 werkzeug==0.16.0
 wheel


### PR DESCRIPTION
To try and get CI passing again.

This is likely unnecessary (and undesirable) upstream.