### PR TITLE
Fix download --constraint for legacy-resolver.

### DIFF
--- a/news/9283.bugfix.rst
+++ b/news/9283.bugfix.rst
@@ -1,0 +1,1 @@
+Fix the download command when using --constraint with the legacy-resolver.

--- a/src/pip/_internal/commands/download.py
+++ b/src/pip/_internal/commands/download.py
@@ -133,7 +133,7 @@ class DownloadCommand(RequirementCommand):
 
         downloaded = []  # type: List[str]
         for req in requirement_set.requirements.values():
-            if req.satisfied_by is None:
+            if req.link and req.satisfied_by is None:
                 assert req.name is not None
                 preparer.save_linked_requirement(req)
                 downloaded.append(req.name)

--- a/tests/functional/test_download.py
+++ b/tests/functional/test_download.py
@@ -60,6 +60,25 @@ def test_download_wheel(script, data):
     result.did_not_create(script.site_packages / 'piptestpackage')
 
 
+def test_download_wheel_constraints(script, data):
+    """
+    Test using "pip download" to download a *.whl with constraints.
+    """
+    script.scratch_path.joinpath("constraints.txt").write_text(textwrap.dedent("""
+        meta==1.0
+        parent==0.1
+        """))
+    result = script.pip(
+        'download',
+        '--no-index',
+        '-f', data.packages,
+        '-d', '.', 'meta',
+        '--constraint', script.scratch_path / 'constraints.txt',
+    )
+    result.did_create(Path('scratch') / 'meta-1.0-py2.py3-none-any.whl')
+    result.did_not_create(script.site_packages / 'piptestpackage')
+
+
 @pytest.mark.network
 def test_single_download_from_requirements_file(script):
     """


### PR DESCRIPTION
Download was not filtering out constraint-only requirements prior to
attempting to save them. Add a failing test under `--resolver=legacy`
and fix by adding in the filtering.

See: https://github.com/pypa/pip/commit/b28e2c4928cc62d90b738a4613886fb1e2ad6a81#r45135982

Fixes #9283